### PR TITLE
add note about released and latest docs

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -10,6 +10,11 @@ The code is open source, and `available on GitHub`_.
 
 .. _available on GitHub: http://github.com/colcon
 
+The documentation exists in two version:
+
+* `released <http://colcon.readthedocs.io/en/released/>`_: matching the latest released version of all packages
+* `latest <http://colcon.readthedocs.io/en/latest/>`_: matching the latest state on the default branch of all packages
+
 The documentation is organized into a few sections:
 
 * :ref:`user-docs`


### PR DESCRIPTION
I am not aware of a way to highlight the version the user is currently seeing. If anybody has a suggestion how to achieve that I would be more than happy to integrate that feature.