### PR TITLE
add requirements.txt file

### DIFF
--- a/developer/bootstrap.rst
+++ b/developer/bootstrap.rst
@@ -61,11 +61,12 @@ Ignore ``colcon-argcomplete`` and ``colcon-bash`` on Windows.
 Dependencies
 ------------
 
-Make sure the required dependencies are available:
+Make sure the dependencies are available:
 
 .. code-block:: bash
 
-    $ pip install -U EmPy
+    $ curl --output requirements.txt https://raw.githubusercontent.com/colcon/colcon.readthedocs.org/master/requirements.txt
+    $ pip install -r requirements.txt
 
 
 Build the sources - first time

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+catkin_pkg
+EmPy
+pytest
+PyYAML


### PR DESCRIPTION
Reverts colcon/colcon.readthedocs.org#11

This instructions is not necessary since all `colcon` package which need `EmPy` declare it as an `install_requires`, e.g. https://github.com/colcon/colcon-core/blob/89edc0fb605edd8980fd1d4c25c6fd5095cc6ab4/setup.cfg#L28.