### PR TITLE
update install-from-source instructions to use colcon-common-extensions

### DIFF
--- a/user/installation.rst
+++ b/user/installation.rst
@@ -68,7 +68,7 @@ In order to use the latest state of any of the above packages you can invoke ``p
 
 .. code-block:: bash
 
-    $ pip install -U git+https://github.com/colcon/colcon-core.git
+    $ pip install -U git+https://github.com/colcon/colcon-common-extensions.git
 
 Building from source
 --------------------


### PR DESCRIPTION
Which will pull in `colcon-core` as well as common extensions.