### PR TITLE
list optional dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,12 @@
+argcomplete; sys_platform != 'win32'
 catkin_pkg
+coloredlogs; sys_platform == 'win32'
 EmPy
+notify2; sys_platform == 'linux'
+pypiwin32; sys_platform == 'win32'
 pytest
+pytest-cov
+pytest-repeat
+pytest-rerunfailures
 PyYAML
+setuptools


### PR DESCRIPTION
Fixes colcon/colcon-core#20.

Collected from the `install_requires` of all common extensions.