### PR TITLE
clarify current behavior of repeat-until-fail for pytest tests

### DIFF
--- a/migration/ament_tools.rst
+++ b/migration/ament_tools.rst
@@ -91,8 +91,9 @@ ament test_results
 Behavioral changes
 ------------------
 
-``--retest-until-fail`` with ``colcon`` uses `pytest-repeat <https://github.com/pytest-dev/pytest-repeat>`_ which runs individual tests of a package N times each (the first test N times, then the second test N times, etc).
-With ``ament_tools`` the entire test suite of a package was run up to N times.
+``--retest-until-fail`` with ``colcon`` uses `pytest-repeat <https://github.com/pytest-dev/pytest-repeat>`_ which runs individual tests of a package N+1 times each (the first test N+1 times, then the second test N+1 times, etc).
+With ``ament_tools`` the entire test suite of a package was run up to N+1 times.
 As a consequence ``colcon`` provides a more accurate result since each test that passed has actually run N times.
+Note that with `pytest-repeat`, `pytest` tests are repeated N times regardless of the result of the previous runs. If a test fails it will be repeated N times anyway. This is different from the behavior of a `Ctest <https://cmake.org/cmake/help/v3.5/manual/ctest.1.html>`_ test that will stop being repeated as soon as it fails once.
 
 The location of JUnit test results file for ``ament_python`` packages tested with ``colcon`` is in ``<pkg-build>/pytest.xml``, whereas with ``ament_tools`` it is in ``<pkg-build>/test_results/<pkgname>/pytest.xunit.xml``.

--- a/migration/ament_tools.rst
+++ b/migration/ament_tools.rst
@@ -94,6 +94,7 @@ Behavioral changes
 ``--retest-until-fail`` with ``colcon`` uses `pytest-repeat <https://github.com/pytest-dev/pytest-repeat>`_ which runs individual tests of a package N+1 times each (the first test N+1 times, then the second test N+1 times, etc).
 With ``ament_tools`` the entire test suite of a package was run up to N+1 times.
 As a consequence ``colcon`` provides a more accurate result since each test that passed has actually run N times.
-Note that with `pytest-repeat`, `pytest` tests are repeated N times regardless of the result of the previous runs. If a test fails it will be repeated N times anyway. This is different from the behavior of a `Ctest <https://cmake.org/cmake/help/v3.5/manual/ctest.1.html>`_ test that will stop being repeated as soon as it fails once.
+Note that with `pytest-repeat`, `pytest` tests are repeated N times regardless of the result of the previous runs; if a test fails it will be repeated N times anyway.
+This is different from the behavior of a `CTest <https://cmake.org/cmake/help/v3.5/manual/ctest.1.html>`_ test that will stop being repeated as soon as it fails once.
 
 The location of JUnit test results file for ``ament_python`` packages tested with ``colcon`` is in ``<pkg-build>/pytest.xml``, whereas with ``ament_tools`` it is in ``<pkg-build>/test_results/<pkgname>/pytest.xunit.xml``.

--- a/migration/ament_tools.rst
+++ b/migration/ament_tools.rst
@@ -94,7 +94,7 @@ Behavioral changes
 ``--retest-until-fail`` with ``colcon`` uses `pytest-repeat <https://github.com/pytest-dev/pytest-repeat>`_ which runs individual tests of a package N+1 times each (the first test N+1 times, then the second test N+1 times, etc).
 With ``ament_tools`` the entire test suite of a package was run up to N+1 times.
 As a consequence ``colcon`` provides a more accurate result since each test that passed has actually run N times.
-Note that with `pytest-repeat`, `pytest` tests are repeated N times regardless of the result of the previous runs; if a test fails it will be repeated N times anyway.
+Note that with ``pytest-repeat``, ``pytest`` tests are repeated N times regardless of the result of the previous runs; if a test fails it will be repeated N times anyway.
 This is different from the behavior of a `CTest <https://cmake.org/cmake/help/v3.5/manual/ctest.1.html>`_ test that will stop being repeated as soon as it fails once.
 
 The location of JUnit test results file for ``ament_python`` packages tested with ``colcon`` is in ``<pkg-build>/pytest.xml``, whereas with ``ament_tools`` it is in ``<pkg-build>/test_results/<pkgname>/pytest.xunit.xml``.


### PR DESCRIPTION
attempt to clarify the behavior of --repeat-until-fail depending on the type of tests.
Also fixed the original description that suggested the tests are ran N times and repeated N times

related to https://github.com/ros2/build_cop/issues/121