### PR TITLE
Add colcon-pkg-config

### DIFF
--- a/colcon.repos
+++ b/colcon.repos
@@ -51,6 +51,10 @@ repositories:
     type: git
     url: https://github.com/colcon/colcon-parallel-executor.git
     version: master
+  colcon-pkg-config:
+    type: git
+    url: https://github.com/colcon/colcon-pkg-config.git
+    version: master
   colcon-powershell:
     type: git
     url: https://github.com/colcon/colcon-powershell.git


### PR DESCRIPTION
`colcon-ros` requires `colcon-pkg-config`. If it is missing then a traceback is printed for every package when bootstrapping colcon using these instructions https://colcon.readthedocs.io/en/released/developer/bootstrap.html

```
[1.783s] ERROR:colcon.colcon_core.entry_point:Exception loading extension 'colcon_core.task.build.ros': The 'colcon-pkg-con
fig' distribution was not found and is required by the application
Traceback (most recent call last):
  File "/home/developer/cc_ws/install/colcon-core/lib/python3.6/site-packages/colcon_core/entry_point.py", line 98, in load
_entry_points
    extension_type = load_entry_point(entry_point)
  File "/home/developer/cc_ws/install/colcon-core/lib/python3.6/site-packages/colcon_core/entry_point.py", line 140, in loa
d_entry_point
    return entry_point.load()
  File "/home/developer/cc_ws/env/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2317, in load
    self.require(*args, **kwargs)
  File "/home/developer/cc_ws/env/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2340, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "/home/developer/cc_ws/env/lib/python3.6/site-packages/pkg_resources/__init__.py", line 774, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'colcon-pkg-config' distribution was not found and is required by the application
```