### PR TITLE
remove obsolete space prefix

### DIFF
--- a/migration/ament_tools.rst
+++ b/migration/ament_tools.rst
@@ -47,17 +47,16 @@ ament build
 ``colcon build ...``
 
 ``--cmake-args -D... --``
-  ``--cmake-args " -D..."``
-  Any CMake arguments which start with a dash need to be prefixed with a space.
-  This can be done by quoting each argument with a leading space.
+  ``--cmake-args -D...``
   The closing double dash is not necessary anymore.
+  Any CMake arguments which match colcon arguments need to be prefixed with a space.
+  This can be done by quoting each argument with a leading space.
 
 ``--force-cmake-configure``
   ``--cmake-force-configure``
 
 ``--use-ninja``
-  ``--cmake-args " -G" Ninja``
-  See ``--cmake-args`` for the reason for the quoting and prefixed space.
+  ``--cmake-args -G Ninja``
 
 ament test
 ----------

--- a/migration/catkin_make_isolated.rst
+++ b/migration/catkin_make_isolated.rst
@@ -20,22 +20,20 @@ The following describes the mapping of some ``catkin_make_isolated`` options and
   ``--merge-install``
 
 ``--use-ninja``
-  ``--cmake-args " -G" Ninja``
-  See ``--cmake-args`` for the reason for the quoting and prefixed space.
+  ``--cmake-args -G Ninja``
 
 ``--use-nmake``
-  ``--cmake-args " -G" "NMake Makefiles"``
-  See ``--cmake-args`` for the reason for the quoting and prefixed space.
+  ``--cmake-args -G "NMake Makefiles"``
 
 ``--install``
   colcon always performs an installation.
   It doesn't support the concept of a "devel" space.
 
 ``--cmake-args ...``
-  ``--cmake-args " -D..."``
-  Any CMake arguments which start with a dash need to be prefixed with a space.
-  This can be done by quoting each argument with a leading space.
+  ``--cmake-args ...``
   The closing double dash is not necessary anymore.
+  Any CMake arguments which match colcon arguments need to be prefixed with a space.
+  This can be done by quoting each argument with a leading space.
 
 ``--force-cmake``
   ``--cmake-force-configure``

--- a/migration/catkin_tools.rst
+++ b/migration/catkin_tools.rst
@@ -19,10 +19,10 @@ catkin build
   ``--cmake-force-configure``
 
 ``--cmake-args ... --``
-  ``--cmake-args " -D..."``
-  Any CMake arguments which start with a dash need to be prefixed with a space.
-  This can be done by quoting each argument with a leading space.
+  ``--cmake-args ...``
   The closing double dash is not necessary anymore.
+  Any CMake arguments which match colcon arguments need to be prefixed with a space.
+  This can be done by quoting each argument with a leading space.
 
 ``-v``, ``--verbose``
   ``--event-handler console_cohesion+``


### PR DESCRIPTION
Remove space prefix from common arguments (except if they collide with colcon arguments).

This is not needed anymore since colcon/colcon-core#63 was implemented.