### PR TITLE
Replace `catkin` mis-reference with `colcon`

### DIFF
--- a/user/quick-start.rst
+++ b/user/quick-start.rst
@@ -15,8 +15,8 @@ The following is an example workflow and sequence of commands using default sett
     $ <...>                           # Populate the `src` directory with packages
     $ colcon list -g                  # List all packages in the workspace and their dependencies
     $ colcon build                    # Build all packages in the workspace
-    $ catkin test                     # Test all packages in the workspace
-    $ catkin test-result --all        # Enumerate all test results
+    $ colcon test                     # Test all packages in the workspace
+    $ colcon test-result --all        # Enumerate all test results
     $ . install/local_setup.bash      # Setup the environment to use the built packages
     $ <...>                           # Use the built packages
 


### PR DESCRIPTION
See https://github.com/colcon/colcon-core/issues/103