### PR TITLE
Added colcon-mixin to the source colcon repos

### DIFF
--- a/colcon.repos
+++ b/colcon.repos
@@ -79,3 +79,7 @@ repositories:
     type: git
     url: https://github.com/colcon/colcon-test-result.git
     version: master
+  colcon-zsh:
+    type: git
+    url: https://github.com/colcon/colcon-zsh.git
+    version: master

--- a/colcon.repos
+++ b/colcon.repos
@@ -32,6 +32,7 @@ repositories:
     url: https://github.com/colcon/colcon-metadata.git
     version: master
   colcon-mixin:
+    type: git
     url: https://github.com/colcon/colcon-mixin.git
     version: master
   colcon-notification:

--- a/colcon.repos
+++ b/colcon.repos
@@ -31,6 +31,9 @@ repositories:
     type: git
     url: https://github.com/colcon/colcon-metadata.git
     version: master
+  colcon-mixin:
+    url: https://github.com/colcon/colcon-mixin.git
+    version: master
   colcon-notification:
     type: git
     url: https://github.com/colcon/colcon-notification.git


### PR DESCRIPTION
I went through the build from source instructions trying to setup the `mixin` verb, but that repo was missing from the given list. 