### PR TITLE
update instructions for GPG key for apt repos to match upstream

### DIFF
--- a/user/installation.rst
+++ b/user/installation.rst
@@ -19,14 +19,14 @@ You can choose either of the two following apt repositories.
   .. code-block:: bash
 
       $ sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list'
-      $ sudo apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+      $ sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 * `ROS 2 repository <https://github.com/ros2/ros2/wiki/Linux-Install-Debians#setup-sources>`_
 
   .. code-block:: bash
 
       $ sudo sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
-      $ curl http://repo.ros2.org/repos.key | sudo apt-key add -
+      $ curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
 
 After that you can install the Debian package which depends on ``colcon-core`` as well as commonly used extension packages (see `setup.cfg <https://github.com/colcon/colcon-common-extensions/blob/master/setup.cfg>`_).
 


### PR DESCRIPTION
Fixes #46.