### PR TITLE
add high level program flow for list and build verbs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -39,6 +39,7 @@ release = u''
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.graphviz',
 ]
 try:
     import sphinxcontrib.spelling  # noqa: F401

--- a/developer/program-flow.rst
+++ b/developer/program-flow.rst
@@ -1,0 +1,57 @@
+Program flow
+============
+
+The following depicts the high level program flow of a couple of verbs.
+
+list
+----
+
+This verb is provided by the ``colcon-package-information`` package.
+
+.. digraph:: list
+
+   initial [shape="point", width="0.2"];
+   initial -> get_package_descriptors [label=" args"];
+   get_package_descriptors -> topological_order_packages [label=" set(pkg descriptor)"];
+   topological_order_packages -> select_package_decorators [label=" list(pkg decorator)"];
+   select_package_decorators -> decision [label=" list(pkg decorator)"];
+   decision [label="", shape="diamond"];
+
+   merge [label="", shape="diamond"];
+   decision:sw -> merge:nw [xlabel=" alphabetical order "];
+   decision:se -> merge:ne [label=" topological order"];
+
+   merge -> print [label=" list(pkg decorator)"];
+   print [label="print pkg name / path / type"];
+   print -> activity_final;
+   activity_final [label="", shape="circle", width="0.2"];
+
+build
+-----
+
+This verb is provided by the ``colcon-core`` package.
+
+.. digraph:: list
+
+   initial [shape="point", width="0.2"];
+   initial -> get_package_descriptors [label=" args"];
+
+   subgraph cluster_get_packages {
+      color = "gray";
+      label = "get_packages";
+      labeljust = "l";
+      get_package_descriptors -> topological_order_packages [label=" set(pkg descriptor)"];
+      topological_order_packages -> select_package_decorators [label=" list(pkg decorator)"];
+      select_package_decorators -> decision [label=" list(pkg decorator)"];
+      decision [label="", shape="diamond"];
+
+      decision -> flow_final [label=" duplicate pkg names"];
+      flow_final [fixedsize="true", label="✕", shape="circle", width="0.18"];
+      {rank = same; decision; flow_final;}
+   }
+
+   decision -> get_jobs [label=" no duplicates"];
+   get_jobs -> execute_jobs [label=" OrderedDict(job)"];
+   execute_jobs -> create_prefix_scripts [label=" rc"];
+   create_prefix_scripts -> activity_final [label=" rc"]
+   activity_final [fillcolor="black", label="", shape="doublecircle", style="filled", width="0.2"];

--- a/index.rst
+++ b/index.rst
@@ -44,6 +44,7 @@ Information about development is also available:
    developer/design
    developer/bootstrap
    developer/environment
+   developer/program-flow
    developer/contribution
    developer/changelog
 


### PR DESCRIPTION
Based on questions in colcon/colcon-core#262.

The `list` verb diagram: 
![list](https://user-images.githubusercontent.com/1335366/68271469-78d8aa80-0015-11ea-9c26-8a99cef69987.png)

The `build` verb diagram:
![build](https://user-images.githubusercontent.com/1335366/68271489-83933f80-0015-11ea-8114-895672eb5d67.png)
