### PR TITLE
document default values for root parser arguments

### DIFF
--- a/user/configuration.rst
+++ b/user/configuration.rst
@@ -100,6 +100,7 @@ The location can also be modified using the environment variable ``COLCON_DEFAUL
 The first level of the configuration file is a dictionary.
 The key is the ``verb`` name.
 In the case of more than one nested verbs the key is the names separated by dots.
+To specify configuration options *before* the first verb use an empty string key.
 The value is another dictionary containing the verb specific configuration.
 
 Verb specific configuration


### PR DESCRIPTION
As implemented in colcon/colcon-defaults#22.