### PR TITLE
Colcon mixin documentation outlines potential for misuse (overlapping parameters)

### DIFF
--- a/reference/mixin-arguments.rst
+++ b/reference/mixin-arguments.rst
@@ -34,14 +34,15 @@ execute merges of **arguments that appear multiple times** correctly.  Those
 conditions arise, for example, when **mixin1** and **mixin2** contain
 overlapping parameters, or when any **mixin** specifies an argument that also
 appears on the command line.  This situation should be avoided since one of
-the parameters will be silently suppressed and thus not yield the desired
-result.  Case in point:
+the parameters will be silently suppressed and the resulting outcome not as
+expected. Case in point:
 
 \\--mixin debug coverage-gcc
-  Will *clash* since both mixins share the ``--cmake-args`` parameter.
+  Will *clash* since both mixins share the ``--cmake-args`` parameter.  One of
+  them will be ignored in the final CMake call.
 
 \\--cmake-args -DCMAKE_BUILD_TYPE=Debug --mixin coverage-gcc
   Will *clash* since mixin and command line share the ``--cmake-args``
   parameter.
 
-To ensure expected results, arguments should be *mutually exclusive*.
+To ensure expected results, arguments should always be *mutually exclusive*.

--- a/reference/mixin-arguments.rst
+++ b/reference/mixin-arguments.rst
@@ -34,8 +34,8 @@ execute merges of **arguments that appear multiple times** correctly.  Those
 conditions arise, for example, when **mixin1** and **mixin2** contain
 overlapping parameters, or when any **mixin** specifies an argument that also
 appears on the command line.  This situation should be avoided since one of
-the parameters will be silently suppressed and the resulting outcome not as
-expected. Case in point:
+the parameters will be silently suppressed and the outcome not be as expected.
+Case in point:
 
 \\--mixin debug coverage-gcc
   Will *clash* since both mixins share the ``--cmake-args`` parameter.  One of
@@ -45,4 +45,4 @@ expected. Case in point:
   Will *clash* since mixin and command line share the ``--cmake-args``
   parameter.
 
-To ensure expected results, arguments should always be *mutually exclusive*.
+Arguments should thus always be *mutually exclusive*.

--- a/reference/mixin-arguments.rst
+++ b/reference/mixin-arguments.rst
@@ -27,3 +27,21 @@ The following arguments are provided by the ``colcon-mixin`` package:
   * **debug**:
 
     - ``cmake-args``: ``['-DCMAKE_BUILD_TYPE=Debug']``
+
+It is important to note that in their current implementation, mixins do not
+possess semantic knowledge about CMake arguments that would allow them to
+execute merges of **arguments that appear multiple times** correctly.  Those
+conditions arise, for example, when **mixin1** and **mixin2** contain
+overlapping parameters, or when any **mixin** specifies an argument that also
+appears on the command line.  This situation should be avoided since one of
+the parameters will be silently suppressed and thus not yield the desired
+result.  Case in point:
+
+\\--mixin debug coverage-gcc
+  Will *clash* since both mixins share the ``--cmake-args`` parameter.
+
+\\--cmake-args -DCMAKE_BUILD_TYPE=Debug --mixin coverage-gcc
+  Will *clash* since mixin and command line share the ``--cmake-args``
+  parameter.
+
+To ensure expected results, arguments should be *mutually exclusive*.


### PR DESCRIPTION
This proposes a *mixin* documentation fix to describe the potential for misuse when 
a. multiple mixins share parameters among each other, or
b. any one mixin shares parameters with the CLI.

It came out of the discussion in https://github.com/colcon/colcon-mixin/issues/20.
