### PR TITLE
document --packages-above-and-dependencies instead of nested invocation of build and list

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -33,7 +33,20 @@ Information about development is also available:
    user/installation
    user/quick-start
    user/configuration
+   user/available-extensions
    user/how-to
+
+.. _verb-details:
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Verb Details
+
+   verb/build
+   verb/info
+   verb/list
+   verb/test
+   verb/test-result
 
 .. _reference-docs:
 

--- a/reference/package-selection-arguments.rst
+++ b/reference/package-selection-arguments.rst
@@ -31,6 +31,12 @@ For each argument the name in brackets indicates which package contributes it.
   Select the packages with the passed names as well as packages which
   recursively depend on them.
 
+.. _package-selection-args_packages-above-and-dependencies_arg:
+
+\\--packages-above-and-dependencies [PKG_NAME [PKG_NAME ...]]
+  Select the packages with the passed names, packages which
+  recursively depend on them as well as their recursive dependencies.
+
 .. _package-selection-args_packages-above-depth_arg:
 
 \\--packages-above-depth DEPTH [PKG_NAME ...]

--- a/user/how-to.rst
+++ b/user/how-to.rst
@@ -76,18 +76,17 @@ Finally, run ``colcon build --symlink-install`` as usual.
 Test selected packages as well as their dependents
 --------------------------------------------------
 
-If you have built the relevant packages before you can run the tests the same way as described in the previous section:
+If you have built the relevant packages before you can run the tests the same way as described in the :ref:`previous section <Rebuild packages which depend on a specific package>`:
 
 .. code-block:: bash
 
     $ colcon test --packages-above <name-of-pkg>
 
-If you haven't built the relevant packages before you can do that by using one invocation to determine all dependents and a second invocation to invoke the actual build:
+If you haven't built the relevant packages before you can build the to-be-tested packages as well as their recursive dependencies with:
 
 .. code-block:: bash
 
-    $ colcon list -n --packages-above <name-of-pkg>
-    $ colcon build --packages-up-to <copy-n-paste-output-previous-command>
+    $ colcon build --packages-above-and-dependencies <name-of-pkg>
 
 Run specific tests
 ------------------


### PR DESCRIPTION
Document easier usage using the new option added in colcon/colcon-package-selection#35,