### PR TITLE
Add in documentation for colcon-ed

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -55,6 +55,7 @@ Information about development is also available:
    :caption: Reference
 
    reference/verb/build
+   reference/verb/edit
    reference/verb/graph
    reference/verb/info
    reference/verb/list

--- a/reference/verb/edit.rst
+++ b/reference/verb/edit.rst
@@ -16,13 +16,14 @@ file with an editor.
     To enable auto-complete, check out the 
     :doc:`installation guide <../../user/installation>`.
 
-Hidden files and ``.pyc`` files are ignored. If multiple files under 
-the same name are present, they will all be listed and you can type in 
-the index number to select which file to edit.
+Hidden files and ``.pyc`` files are ignored. 
+If multiple files under the same name are present, they will all be listed 
+and you can type in the index number to select which file to edit.
 
 By default, ``vim`` is the editor that will be used, but you can also use 
 other editors by specifying ``$EDITOR`` environment variable to the ones
-preferred. For example, to use **Visual Studio Code**, simply run
+preferred. 
+For example, to use **Visual Studio Code**, simply run
 
 .. code-block:: bash
 

--- a/reference/verb/edit.rst
+++ b/reference/verb/edit.rst
@@ -1,0 +1,50 @@
+``edit`` - Edit File
+====================
+
+The ``edit`` search and edit a file inside a package using command line.
+It is provided by the ``colcon-ed`` package.
+
+When a correct package name and file name is provided, it will open that
+file with an editor. 
+
+.. code-block:: bash
+
+    $ colcon edit <package_name> <file_name>
+
+.. note::
+
+    To enable auto-complete, check out the 
+    :doc:`installation guide <../../user/installation>`.
+
+Hidden files and ``.pyc`` files are ignored. If multiple files under 
+the same name are present, they will all be listed and you can type in 
+the index number to select which file to edit.
+
+By default, ``vim`` is the editor that will be used, but you can also use 
+other editors by specifying ``$EDITOR`` environment variable to the ones
+preferred. For example, to use **Visual Studio Code**, simply run
+
+.. code-block:: bash
+
+    $ export EDITOR=code
+
+
+Command line arguments
+----------------------
+
+These common arguments can be used:
+
+* :doc:`discovery <../discovery-arguments>` arguments
+* :doc:`mixin <../mixin-arguments>` arguments
+
+The following specific positional arguments are used:
+
+.. _edit-verb_package-name_arg:
+
+PKG_NAME
+  Explicit package name to specify which package the file is in.
+
+.. _edit-verb_file-name_arg:
+
+FILE_NAME
+  File name to specify which file to edit.


### PR DESCRIPTION
Addresses https://github.com/colcon/colcon-ed/issues/12

This PR adds the documentation for [**colcon-ed**](https://github.com/colcon/colcon-ed) .

I added in another verb inside the reference folder.

## Bug Report

I also find that in PR #68 and my own CI [log](https://travis-ci.org/github/Briancbn/colcon.readthedocs.org/builds/687946664) there is an error during `sudo apt-get update` 

It is mainly due to some google-chrome keys couldn't be verified. I added in a simple fix that will add the updated keys for google. I am not sure it is the best solution, but it does the job for now.
https://github.com/colcon/colcon.readthedocs.org/blob/c3e89cd231301b12b1da91a4769928a22db47e9e/.travis.yml#L6
