### PR TITLE
Do minor documentation changes

### DIFF
--- a/developer/bootstrap.rst
+++ b/developer/bootstrap.rst
@@ -5,7 +5,7 @@ When developing ``colcon`` you want to have a local checkout of all involved pac
 
 .. note::
 
-    The following steps us the command line tool `vcstool <https://github.com/dirk-thomas/vcstool/>`_ to fetch a set of repositories.
+    The following steps use the command line tool `vcstool <https://github.com/dirk-thomas/vcstool/>`_ to fetch a set of repositories.
     You can e.g. install it using ``pip install vcstool``.
 
 .. note::

--- a/developer/environment.rst
+++ b/developer/environment.rst
@@ -24,9 +24,9 @@ Package-level
 
 .. note::
 
-    Each package installs its files under its install prefix. This corresponds
-    to ``install/<package_name>`` except when ``colcon build
-    --merge-install`` is used. In that case, the install prefix is ``install/``.
+    Each package installs its files under its install prefix.
+    This corresponds to ``install/<package_name>`` except when ``colcon build --merge-install`` is used.
+    In that case, the install prefix is ``install/``.
 
 For each built package ``colcon`` generates a set of package-level scripts (one for each supported shell type): ``share/<package_name>/package.<ext>``.
 These script files update the environment with information specific to this package.

--- a/developer/environment.rst
+++ b/developer/environment.rst
@@ -22,6 +22,12 @@ To update environment variables:
 Package-level
 ~~~~~~~~~~~~~
 
+.. note::
+
+    Each package installs its files under its install prefix. This corresponds
+    to ``install/<package_name>`` except when ``colcon build
+    --merge-install`` is used. In that case, the install prefix is ``install/``.
+
 For each built package ``colcon`` generates a set of package-level scripts (one for each supported shell type): ``share/<package_name>/package.<ext>``.
 These script files update the environment with information specific to this package.
 

--- a/user/quick-start.rst
+++ b/user/quick-start.rst
@@ -124,7 +124,7 @@ Before building the workspace with ``colcon`` the steps also fetch some addition
     $ colcon metadata update
     $ colcon build
 
-To run Gazebo which requires environment variables for e.g. the model paths the same commands as for other packages can be used.
+To run Gazebo, which requires environment variables for e.g., the model paths, the same commands as for other packages can be used.
 Using the additional metadata the source script will also automatically source the Gazebo specific file ``share/gazebo/setup.sh`` which defines these environment variables.
 
 .. code-block:: bash


### PR DESCRIPTION
- Typo: s/us/use
- Package shell script is stored under `<package_name>/share/<package_name>/... .<ext>` with regards to install directory
- Amend Gazebo-colcon description