### PR TITLE
Fix undefined label

### DIFF
--- a/user/how-to.rst
+++ b/user/how-to.rst
@@ -44,6 +44,8 @@ Build selected packages including their dependencies
 
     $ colcon build --packages-up-to <name-of-pkg>
 
+.. _rebuild_packages:
+
 Rebuild packages which depend on a specific package
 ---------------------------------------------------
 
@@ -76,7 +78,7 @@ Finally, run ``colcon build --symlink-install`` as usual.
 Test selected packages as well as their dependents
 --------------------------------------------------
 
-If you have built the relevant packages before you can run the tests the same way as described in the :ref:`previous section <Rebuild packages which depend on a specific package>`:
+If you have built the relevant packages before you can run the tests the same way as described in the :ref:`previous section <rebuild_packages>`:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Current PR fixes an undefined label reported when running `make html` manually.

```
writing output... [100%] user/quick-start
/home/berger/src/colcon/colcon.readthedocs.org/user/how-to.rst:81: WARNING: undefined label: rebuild_packages_ (if the link has no caption the label must precede a section header)
generating indices...  genindexdone
```

Here's how the section at hand looks before and after the fix:

Before:

![1604476568-screenshot](https://user-images.githubusercontent.com/5816719/98084972-887f0f00-1e74-11eb-9855-afd3d6575f3e.png)

After:

![1604476557-screenshot](https://user-images.githubusercontent.com/5816719/98084975-8917a580-1e74-11eb-8e8d-a41577798b42.png)

Would it  be worth checking for broken links as part of the CI?
There's the sphinx `linkcheck` script which can be used for such purpose: `sphinx-server sphinx-build -b linkcheck`

https://www.sphinx-doc.org/en/master/_modules/sphinx/builders/linkcheck.html