### PR TITLE
migration: CMake doesn't recognise '-G Ninja'

### DIFF
--- a/migration/ament_tools.rst
+++ b/migration/ament_tools.rst
@@ -60,7 +60,7 @@ ament build
   When using this option to control the parallel execution with arguments like ``-jN`` the substitution is to use the environment variable ``MAKEFLAGS``.
 
 ``--use-ninja``
-  ``--cmake-args -G Ninja``
+  ``--cmake-args -G "Ninja"``
 
 ament test
 ----------

--- a/migration/catkin_make_isolated.rst
+++ b/migration/catkin_make_isolated.rst
@@ -20,7 +20,7 @@ The following describes the mapping of some ``catkin_make_isolated`` options and
   ``--merge-install``
 
 ``--use-ninja``
-  ``--cmake-args -G Ninja``
+  ``--cmake-args -G "Ninja"``
 
 ``--use-nmake``
   ``--cmake-args -G "NMake Makefiles"``


### PR DESCRIPTION
As per subject.

This may be something local to my setup (Windows), but Colcon is the latest version (from `pip`) and CMake is version `3.16.3` -- by which I mean "it's not like I'm using outdated versions necessarily".
