### PR TITLE
Fix bootstrap from source instructions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ argcomplete; sys_platform != 'win32'
 catkin_pkg
 coloredlogs; sys_platform == 'win32'
 distlib
-EmPy
+EmPy<4
 notify2; sys_platform == 'linux'
 pypiwin32; sys_platform == 'win32'
 pytest


### PR DESCRIPTION
Pins `EmPy<4` to fix the error:

    ImportError: cannot import name 'OVERRIDE_OPT' from 'em'

This fixes the "Bootstrap from source" instructions, which is using this file to install requirements.