### PR TITLE
Update requirements.txt to pin EmPy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ argcomplete; sys_platform != 'win32'
 catkin_pkg
 coloredlogs; sys_platform == 'win32'
 distlib
-EmPy
+EmPy<4
 notify2; sys_platform == 'linux'
 pypiwin32; sys_platform == 'win32'
 pytest


### PR DESCRIPTION
Reflects changes here: https://github.com/colcon/colcon-core/pull/603/

Otherwise building colcon for the first time per https://colcon.readthedocs.io/en/released/developer/bootstrap.html fails due to 

`ImportError: cannot import name 'OVERRIDE_OPT' from 'em' (/$USER_DIR/colcon-venv/lib/python3.11/site-packages/em.py) The Python package 'empy' must be installed and 'em' must not be installed since both packages share the same namespace
`