### PR TITLE
Fix list output documentation

### DIFF
--- a/reference/verb/list.rst
+++ b/reference/verb/list.rst
@@ -4,8 +4,8 @@
 The ``list`` verb enumerates a set of packages.
 It is provided by the ``colcon-package-information`` package.
 
-For each package a line is shown containing the path, name and type separated
-by tabs.
+For each package a line is shown containing the the name, path and type (in
+parentheses) separated by tabs.
 By default the list is ordered alphabetically by the package name.
 Optionally, it can order the packages topologically based on their dependencies.
 

--- a/reference/verb/list.rst
+++ b/reference/verb/list.rst
@@ -4,7 +4,7 @@
 The ``list`` verb enumerates a set of packages.
 It is provided by the ``colcon-package-information`` package.
 
-For each package a line is shown containing the the name, path and type (in
+For each package a line is shown containing the name, path and type (in
 parentheses) separated by tabs.
 By default the list is ordered alphabetically by the package name.
 Optionally, it can order the packages topologically based on their dependencies.


### PR DESCRIPTION
The implementation at https://github.com/colcon/colcon-package-information/blob/master/colcon_package_information/verb/list.py does: `pkg.name + '\t' + str(pkg.path) + '\t(%s)' % pkg.type`

The documentation wasn't precise about this.