### PR TITLE
Pin setuptools in released bootstrap docs

### DIFF
--- a/developer/bootstrap.rst
+++ b/developer/bootstrap.rst
@@ -31,7 +31,7 @@ You might want to make sure that the venv is using up-to-date versions of the so
 
 .. code-block:: bash
 
-    $ pip install -U pip setuptools
+    $ pip install -U pip 'setuptools>=40.5.0,<80'
 
 Fetch the sources
 -----------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ pytest-repeat
 pytest-rerunfailures
 pytest-runner
 PyYAML
-setuptools>=40.5.0
+setuptools>=40.5.0,<80


### PR DESCRIPTION
## Summary
- apply the same `setuptools<80` bound from `main` to the released bootstrap command
- pin the released requirements entry so bootstrapping avoids setuptools versions that no longer provide `pkg_resources`

Closes #109

## Validation
- Read the Docs build passed: `docs/readthedocs.org:colcon`
- Not run locally